### PR TITLE
Devops/ensure input

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY config/gemrc /usr/local/etc/gemrc
 
 COPY src/ /home/runner/
 
-RUN gem update --system && gem install activesupport faraday faraday-retry money nokogiri pry-byebug rexml --no-doc
+RUN gem update --system 3.4.22 && gem install activesupport 'faraday:2.8.1' faraday-retry money 'nokogiri:1.15.6' pry-byebug rexml --no-doc
 
 ENV HOME=/tmp/app-tmp
 ENV TMPDIR=/tmp/app-tmp


### PR DESCRIPTION
Vi har upptäckt problem med encoding när vi skickar in viss input. Detta utökar stödet för att kunna ta emot Base64-encoded input.
Då vi kör äldre Ruby behövde vi här även låsa versionen för `gem upgrade` samt vissa gems.